### PR TITLE
fix: support for SSR

### DIFF
--- a/src/StickToBottom.tsx
+++ b/src/StickToBottom.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as React from 'react';
-import { createContext, ReactNode, RefCallback, useContext, useLayoutEffect, useMemo } from 'react';
+import { createContext, ReactNode, RefCallback, useContext, useEffect, useLayoutEffect, useMemo } from 'react';
 import { ScrollToBottom, StopScroll, StickToBottomOptions, useStickToBottom } from './useStickToBottom.js';
 
 export interface StickToBottomContext {
@@ -25,6 +25,8 @@ export interface StickToBottomProps
   instance?: ReturnType<typeof useStickToBottom>;
   children: ((context: StickToBottomContext) => ReactNode) | ReactNode;
 }
+
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect
 
 export function StickToBottom({
   instance,
@@ -61,7 +63,7 @@ export function StickToBottom({
     [scrollToBottom, isAtBottom, contentRef, escapedFromLock]
   );
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (!scrollRef.current) {
       return;
     }


### PR DESCRIPTION
When using the library with server side rendering (ie, Remix/NextJS), you run into a mismatch caused by the `useLayoutEffect` being only available on the client-side and not doing anything on the server-side.

> Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://reactjs.org/link/uselayouteffect-ssr for common fixes.


This problem can be resolved by implementing a custom hook that uses either `useEffect` or `useLayoutEffect` depending on the environment.